### PR TITLE
Fix: No Seal for Gift/Sand после перезагрузки сервера

### DIFF
--- a/land/land.ts
+++ b/land/land.ts
@@ -442,6 +442,28 @@ namespace $ {
 				
 			}
 
+			// Build hash -> unit map for lookups
+			const unit_by_hash = new Map< string, $giper_baza_unit_base >()
+			for( const gift of this._gift.values() ) {
+				unit_by_hash.set( gift.hash().str, gift )
+			}
+			for( const kids of this._sand.values() ) {
+				for( const peers of kids.values() ) {
+					for( const sand of peers.values() ) {
+						unit_by_hash.set( sand.hash().str, sand )
+					}
+				}
+			}
+
+			// Ensure gifts/sands are included when their seals are in delta
+			for( const unit of [ ... delta ] ) {
+				if( !( unit instanceof $giper_baza_unit_seal ) ) continue
+				for( const hash of unit.hash_list() ) {
+					const covered = unit_by_hash.get( hash.str )
+					if( covered ) delta.add( covered )
+				}
+			}
+
 			// Ensure seals are included for all gifts/sands in delta
 			for( const unit of [ ... delta ] ) {
 				if( unit instanceof $giper_baza_unit_seal ) continue


### PR DESCRIPTION
## Summary

Fixes the "No Seal for Gift" and "No Seal for Sand" errors that occur after restarting server and clients.

### Root Cause Analysis

The issue occurs in the `diff_units()` method in `land/land.ts`. When units are collected to be sent over the network, they are filtered based on `time_tick`:

```typescript
if( unit.time_tick() > face_limit ) return delta.add( unit )
```

As correctly noted by @nin-jin: **`time_tick` for seal is always greater because it's created after the gift/sand.**

This means when the receiver has `face_limit = 100`:
- A seal with `time_tick = 101` is included (101 > 100 is true)
- Its gift/sand with `time_tick = 100` is excluded (100 > 100 is false)

When the receiver gets the seal but not the gift/sand it covers, and later receives the gift/sand separately, it fails with "No Seal for Gift/Sand" because the seal was already sent in a previous batch.

### Solution

Added bidirectional inclusion logic:

1. **When seal is in delta, include all gifts/sands it covers:**
```typescript
// Build hash -> unit map for lookups
const unit_by_hash = new Map< string, $giper_baza_unit_base >()
for( const gift of this._gift.values() ) {
    unit_by_hash.set( gift.hash().str, gift )
}
// ... same for sands

// Ensure gifts/sands are included when their seals are in delta
for( const unit of [ ... delta ] ) {
    if( !( unit instanceof $giper_baza_unit_seal ) ) continue
    for( const hash of unit.hash_list() ) {
        const covered = unit_by_hash.get( hash.str )
        if( covered ) delta.add( covered )
    }
}
```

2. **When gift/sand is in delta, include its seal** (already implemented in previous commit):
```typescript
// Ensure seals are included for all gifts/sands in delta
for( const unit of [ ... delta ] ) {
    if( unit instanceof $giper_baza_unit_seal ) continue
    const seal = this.unit_seal( unit )
    if( seal ) delta.add( seal )
}
```

This guarantees that seals and the units they cover are always sent together.

### Files Changed

- `land/land.ts` - Added bidirectional seal/unit inclusion logic in `diff_units()` method

### Fixes
- giper-dev/baza#1

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes giper-dev/baza#1