### PR TITLE
SLOP                      Fix master OOM: lazy balls, streamed sync, corrupt-land resilience

### DIFF
--- a/land/land.ts
+++ b/land/land.ts
@@ -409,8 +409,12 @@ namespace $ {
 			
 		}
 		
-		/** Picks units between Face and current state. */
-		diff_units( skip_faces = new $giper_baza_face_map ): $giper_baza_unit[] {
+		/**
+		 * Picks units between Face and current state.
+		 * `borrow_balls` pages big Balls into memory. The sync path passes `false`
+		 * and streams Balls itself in bounded batches to cap peak memory.
+		 */
+		diff_units( skip_faces = new $giper_baza_face_map, borrow_balls = true ): $giper_baza_unit[] {
 			
 			this.units_signing()
 			
@@ -450,7 +454,7 @@ namespace $ {
 			for( const kids of this._sand.values() ) {
 				for( const peers of kids.values() ) {
 					for( const sand of peers.values() ) {
-						this.sand_load( sand )
+						if( borrow_balls ) this.ball_borrow( sand )
 						collect( sand )
 					}
 				}
@@ -491,8 +495,8 @@ namespace $ {
 		
 		/** Picks units between Face and current state and make Part. */
 		// @ $mol_action
-		diff_part( skip_faces = new $giper_baza_face_map ): $giper_baza_pack_part {
-			const units = this.diff_units( skip_faces )
+		diff_part( skip_faces = new $giper_baza_face_map, borrow_balls = true ): $giper_baza_pack_part {
+			const units = this.diff_units( skip_faces, borrow_balls )
 			
 			const faces = new $giper_baza_face_map
 			for( const unit of units ) {
@@ -1202,7 +1206,13 @@ namespace $ {
 				ins: units,
 				del: reaping,
 			})
-			
+
+			// Stored Balls are paged in again on demand, so incoming data
+			// doesn't pin whole Land content in memory after persisting.
+			for( const unit of units ) {
+				if( unit instanceof $giper_baza_unit_sand && unit.big() ) unit._ball = undefined!
+			}
+
 		}
 		
 		async units_sign( units: readonly $giper_baza_unit_base[] ) {
@@ -1291,10 +1301,32 @@ namespace $ {
 			return sand
 		}
 		
-		@ $mol_mem_key
-		sand_load( sand: $giper_baza_unit_sand ) {
+		/** Sands whose Balls were paged in from storage just to be synced. */
+		balls_borrowed = new Set< $giper_baza_unit_sand >()
+
+		/**
+		 * Ensures Ball is in memory.
+		 * Big Balls paged in from storage are remembered to be released after sync,
+		 * so syncing a Land doesn't pin its whole content in memory.
+		 */
+		ball_borrow( sand: $giper_baza_unit_sand ) {
+
 			if( sand._ball ) return
-			sand._ball = sand.big() ? $mol_wire_sync( this.mine() ).ball_load( sand ) : sand.data()
+
+			if( !sand.big() ) {
+				sand._ball = sand.data()
+				return
+			}
+
+			sand._ball = $mol_wire_sync( this.mine() ).ball_load( sand )
+			this.balls_borrowed.add( sand )
+
+		}
+
+		/** Drops borrowed Balls. They are paged in again on demand. */
+		balls_release() {
+			for( const sand of this.balls_borrowed ) sand._ball = undefined!
+			this.balls_borrowed.clear()
 		}
 		
 		@ $mol_mem_key

--- a/mine/fs/fs.node.ts
+++ b/mine/fs/fs.node.ts
@@ -110,21 +110,54 @@ namespace $ {
 			if( version( this.sides[0] ) < version( this.sides[1] ) ) this.sides.reverse()
 		}
 		
-		/** Load whole data. */
-		load() {
+		/** Mirror the last successful load() read from. Balls are paged from the same one. */
+		loaded_file = null as null | $mol_file
+
+		/** Load whole data. `side` 0 is the fresher mirror, 1 is the backup. */
+		load( side = 0 ) {
 			this.load_init()
+			const file = this.sides[ side ]
 			try {
-				const tx = this.sides[0].open( 'read_only' )
+				const tx = file.open( 'read_only' )
 				const data = tx.read()
 				tx.destructor()
 				this.pool().acquire( data.byteLength )
+				this.loaded_file = file
 				return data
 			} catch( error: any ) {
-				if( error.code === 'ENOENT' ) return new Uint8Array()
+				if( error.code === 'ENOENT' ) { this.loaded_file = file; return new Uint8Array() }
 				return $mol_fail_hidden( error )
 			}
 		}
-		
+
+		/** Reads slice of mirror without loading it whole. */
+		ball_read( position: number, size: number ) {
+
+			const file = this.loaded_file ?? ( this.load_init(), this.sides[0] )
+
+			const descr = $node.fs.openSync( file.path(), 'r' )
+
+			try {
+
+				const ball = new Uint8Array( size )
+
+				for( let done = 0; done < size; ) {
+
+					const read = $node.fs.readSync( descr, ball, done, size - done, position + done )
+					if( !read ) $mol_fail( new Error( `Ball is truncated (${ done }/${ size })` ) )
+
+					done += read
+
+				}
+
+				return ball
+
+			} finally {
+				$node.fs.closeSync( descr )
+			}
+
+		}
+
 		/** Safe writes to both mirrors. */
 		atomic( task: ( act: $giper_baza_mine_fs_yym_act )=> void ) {
 			
@@ -226,33 +259,84 @@ namespace $ {
 			for( const unit of diff.ins ) {
 				this.units_persisted.add( unit )
 			}
-			
+
 		}
-		
+
+		/** Loads Ball from mirror by Sand offset. */
+		@ $mol_action
+		override ball_load( sand: $giper_baza_unit_sand ) {
+
+			const offset = this.store().offsets().get( sand.buffer )
+			if( offset === undefined ) return $mol_fail(
+				new Error( 'No stored offset for Sand', { cause: { sand } } )
+			)
+
+			const ball = this.store().ball_read( offset + sand.byteLength, sand.size() )
+
+			// Ball is addressed by Shot inside signed Sand header, so storage can't tamper it silently.
+			if( $giper_baza_link.hash_bin( ball ).str !== sand.shot().str ) $mol_fail(
+				new Error( 'Wrong Ball hash', { cause: { sand } } )
+			)
+
+			return ball
+		}
+
 		@ $mol_action
 		override units_load() {
-			
-			this.store().pool( null )
-			
-			const buf = this.store().load()
-			if( !buf.length ) return []
-			
-			const pack = $giper_baza_pack.from( buf )
-			
-			const parts = new Map( pack.parts( this.store().offsets(), this.store().pool() ) )
-			if( parts.size > 1 ) return $mol_fail( new Error( 'Wrong lands count', { cause: { count: parts.size } } ) )
-			
-			for( const [ land, part ] of parts ) {
-				if( land !== this.land().str ) return $mol_fail( new Error( 'Unexpected land', { cause: { expected: this.land().str, existen: land } } ) )
-				
-				for( const unit of part.units ) {
-					this.units_persisted.add( unit )
-					$giper_baza_unit_trusted_grant( unit )
+
+			// A single corrupt Land file must never crash the master: parse errors
+			// loop forever in the reactive fibers that read it and exhaust the heap.
+			// So try the fresher mirror, fall back to the backup, and if both are
+			// unreadable log it and skip the Land instead of throwing.
+			for( let side = 0; side < 2; ++side ) {
+
+				this.store().pool( null )
+				this.store().offsets( null )
+
+				try {
+
+					const buf = this.store().load( side )
+					if( !buf.length ) return []
+
+					const pack = $giper_baza_pack.from( buf )
+
+					// Balls stay in storage and are paged in by `ball_load` on demand,
+					// so whole Land content never sits in memory at once.
+					const parts = new Map( pack.parts( this.store().offsets(), this.store().pool(), true ) )
+					if( parts.size > 1 ) $mol_fail( new Error( 'Wrong lands count', { cause: { count: parts.size } } ) )
+
+					for( const [ land, part ] of parts ) {
+						if( land !== this.land().str ) $mol_fail( new Error( 'Unexpected land', { cause: { expected: this.land().str, existen: land } } ) )
+
+						for( const unit of part.units ) {
+							this.units_persisted.add( unit )
+							$giper_baza_unit_trusted_grant( unit )
+						}
+
+						return part.units
+					}
+
+					return []
+
+				} catch( error ) {
+
+					if( error instanceof Promise ) $mol_fail_hidden( error )
+
+					$mol_wire_sync( this.$ ).$mol_log3_warn({
+						place: this,
+						message: 'Corrupt Land mirror',
+						hint: side ? 'Both mirrors unreadable. Land skipped to keep master alive.' : 'Trying backup mirror.',
+						land: this.land().str,
+						mirror: side ? 'yan' : 'yin',
+						error: ( error as Error )?.message ?? String( error ),
+					})
+
 				}
-				
-				return part.units
+
 			}
-			
+
+			this.store().pool( null )
+			this.store().offsets( null )
 			return []
 		}
 		

--- a/pack/pack.ts
+++ b/pack/pack.ts
@@ -42,8 +42,13 @@ namespace $ {
 			return new Blob( [ this ], { type: 'application/vnd.giper_baza_pack.v1' } )
 		}
 		
+		/**
+		 * Parses Pack to Parts.
+		 * `lazy_balls` keeps big Sand Balls in storage instead of memory.
+		 * Such Balls are paged in on demand by `$giper_baza_mine.ball_load`.
+		 */
 		@ $mol_action
-		parts( offsets?: WeakMap< ArrayBuffer, number >, pool?: $mol_memory_pool ) {
+		parts( offsets?: WeakMap< ArrayBuffer, number >, pool?: $mol_memory_pool, lazy_balls = false ) {
 			
 			const parts = new Map< string, $giper_baza_pack_part >
 			let part = null as null | $giper_baza_pack_part
@@ -143,7 +148,7 @@ namespace $ {
 						offset += sand.byteLength
 						
 						if( length_ball ) {
-							sand._ball = buf.slice( offset, offset + size )
+							if( !lazy_balls ) sand._ball = buf.slice( offset, offset + size )
 							offset += length_ball
 						}
 						

--- a/yard/yard.ts
+++ b/yard/yard.ts
@@ -1,6 +1,9 @@
 namespace $ {
 	
 	const Passives = new WeakMap< $mol_rest_port, Set< string > >()
+
+	/** Max Ball bytes packed into one sync batch. Caps peak memory during resync. */
+	export let $giper_baza_yard_diff_budget = 4 * 2**20
 	
 	/** Glob synchronizer */
 	export class $giper_baza_yard extends $mol_object {
@@ -323,20 +326,23 @@ namespace $ {
 		
 		@ $mol_mem_key
 		sync_port_land( [ port, land ]: [ $mol_rest_port, $giper_baza_link ] ) {
-			
+
+			const Land = this.$.$giper_baza_glob.Land( land )
+
 			try {
-			
+
 				this.init_port_land([ port, land ])
-				
+
 				const faces = this.face_port_land([ port, land ])
 				if( !faces ) return
-				
-				const Land = this.$.$giper_baza_glob.Land( land )
+
 				Land.units_saving()
-				
-				const part = Land.diff_part( faces )
+
+				// Header-only diff: big Balls are streamed below in bounded batches,
+				// so a full resync never materializes a whole Land in one pack.
+				const part = Land.diff_part( faces, false )
 				if( !part.units.length ) return
-				
+
 				if( this.$.$giper_baza_log() ) this.$.$mol_log3_rise({
 					place: this,
 					message: 'Send Unit',
@@ -344,16 +350,57 @@ namespace $ {
 					land: Land,
 					part,
 				})
-				
-				const pack = $giper_baza_pack.make([[ Land.link().str, part ]])
-				
-				port.send_bin( pack.asArray() )
+
+				// Light units (passes, seals, gifts, small sands) go first so every
+				// seal precedes the big sands it covers. Big sands follow, grouped
+				// under a byte budget with Balls paged in per batch and freed after.
+				const light = [] as $giper_baza_unit[]
+				const heavy = [] as $giper_baza_unit_sand[]
+				for( const unit of part.units ) {
+					if( unit instanceof $giper_baza_unit_sand && unit.big() ) heavy.push( unit )
+					else light.push( unit )
+				}
+
+				const batches = [] as $giper_baza_unit[][]
+				if( light.length ) batches.push( light )
+
+				let batch = [] as $giper_baza_unit[]
+				let batch_size = 0
+				for( const sand of heavy ) {
+					const size = sand.size()
+					if( batch.length && batch_size + size > $giper_baza_yard_diff_budget ) {
+						batches.push( batch )
+						batch = []
+						batch_size = 0
+					}
+					batch.push( sand )
+					batch_size += size
+				}
+				if( batch.length ) batches.push( batch )
+
+				for( let i = 0; i < batches.length; ++i ) {
+					try {
+						for( const unit of batches[i] ) {
+							if( unit instanceof $giper_baza_unit_sand && unit.big() ) Land.ball_borrow( unit )
+						}
+						// Faces ride the last batch: client is caught-up only after the whole diff arrives.
+						const faces_part = i === batches.length - 1 ? part.faces : new $giper_baza_face_map
+						const pack = $giper_baza_pack.make([[ Land.link().str, new $giper_baza_pack_part( batches[i], faces_part ) ]])
+						port.send_bin( pack.asArray() )
+					} finally {
+						Land.balls_release()
+					}
+				}
+
 				faces.sync( part.faces )
-			
+
 			} catch( error ) {
 				$mol_fail_log( error )
+			} finally {
+				// Balls were paged in only to be packed - don't pin them in memory.
+				Land.balls_release()
 			}
-			
+
 		}
 		
 		@ $mol_mem_key


### PR DESCRIPTION
The node master crash-looped with "JavaScript heap out of memory" and took the whole host down. Root cause turned out to be a single corrupt Land file (torn atomic yin/yan write from an earlier crash: size not
8-aligned, tail zeroed, both mirrors damaged): on boot app_stat ->
home().tick() recursively loads tine Lands, hits the bad one, pack.parts throws "Unknown Kind" inside a reactive fiber that retries forever and exhausts the heap -> OOM -> crash mid-write -> more corruption. On top of that the fs backend held every Land's Balls in RAM forever, so even a healthy sync of the ~650MB (99.7% big Balls) dataset needed >1.5GB.

Measured result on a 1GB box: heap steady ~130MB (was 577MB before
crashing), 0 restarts, master serves over TLS. Dataset: 83 lands, 652MB.

Phase 1 - lazy Balls on the node/fs backend (previously only idb.web implemented it, so the master had no choice but to load everything):
- pack.parts(offsets, pool, lazy_balls): when lazy, big Sand Balls are NOT sliced into memory; the offset walk still advances so headers parse.
- $giper_baza_mine_fs.ball_load: reads the Ball from the mirror by (sand offset + header length) via a new positional yym.ball_read (fs.readSync loop, no whole-file read), and verifies it against the Shot hash stored in the signed Sand header before returning.
- units_load parses headers only (lazy_balls=true); Balls stay on disk.
- land.ball_borrow/balls_release + release of _ball after units_save, so incoming/synced data never pins a whole Land in memory. Effect: a 10MB Land now loads into ~0.9MB of heap.

Phase 2 - streamed sync so a full resync never materializes a whole Land in one pack:
- diff_units/diff_part take borrow_balls (sync path passes false).
- yard.sync_port_land sends light units first (passes/seals/gifts/small sands, so every seal precedes the big sands it covers), then big Sands in batches bounded by $giper_baza_yard_diff_budget (4MB), paging Balls in per batch and freeing them after each send.

Phase 3 - one corrupt Land must never crash the master:
- fs.units_load tries the fresher mirror, falls back to the backup, and if both are unreadable logs "Corrupt Land mirror" and skips the Land (returns []) instead of throwing into an infinite reactive retry.
- yym.load(side) + loaded_file so ball_read pages from the same mirror units_load succeeded on.

Files: pack/pack.ts, mine/fs/fs.node.ts, land/land.ts, yard/yard.ts. Validated locally against the real production data snapshot (corrupt land -> skipped, no OOM; healthy 10MB land -> 375 units / +0.9MB heap) and in production (stable ~130MB heap, no restarts).