### PR TITLE
поправить тесты BAZA:file после отключения Content-Type

### DIFF
--- a/app/app.node.test.ts
+++ b/app/app.node.test.ts
@@ -24,7 +24,8 @@ namespace $.$$ {
 				}),
 			}) )
 
-			$mol_assert_equal( res, [ 200, 'text/markdown', content ] )
+			// send_type не зовётся: Content-Type отключён как XSS-вектор, тип не отдаём
+			$mol_assert_equal( res, [ 200, content ] )
 
 		},
 
@@ -46,7 +47,7 @@ namespace $.$$ {
 				}),
 			}) )
 
-			$mol_assert_equal( res, [ 404, 'application/octet-stream', new Uint8Array ] )
+			$mol_assert_equal( res, [ 404, new Uint8Array ] )
 
 		},
 


### PR DESCRIPTION
Фикс b90f8c3 закомментировал send_type (XSS через text/html), а ожидания тестов остались старые.