### PR TITLE
поправить тесты BAZA:file под mime_safe

### DIFF
--- a/app/app.node.test.ts
+++ b/app/app.node.test.ts
@@ -24,8 +24,8 @@ namespace $.$$ {
 				}),
 			}) )
 
-			// send_type не зовётся: Content-Type отключён как XSS-вектор, тип не отдаём
-			$mol_assert_equal( res, [ 200, content ] )
+			// не-медийные типы отдаются как octet-stream: text/html был бы XSS-вектором
+			$mol_assert_equal( res, [ 200, 'application/octet-stream', content ] )
 
 		},
 
@@ -47,7 +47,7 @@ namespace $.$$ {
 				}),
 			}) )
 
-			$mol_assert_equal( res, [ 404, new Uint8Array ] )
+			$mol_assert_equal( res, [ 404, 'application/octet-stream', new Uint8Array ] )
 
 		},
 


### PR DESCRIPTION
a1d55c0 вернул Content-Type через $giper_baza_file_mime_safe: не-медийные типы отдаются как application/octet-stream, а тесты ожидали отсутствие типа.