### PR TITLE
watchtower: stop-timeout 60s, no remove-volumes

### DIFF
--- a/app/run/docker-compose.yml
+++ b/app/run/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     image: openserbia/watchtower
     logging:
       driver: "local"
-    command: --interval 300 --cleanup --remove-volumes --log-level warn
+    command: --interval 300 --cleanup --remove-volumes --stop-timeout 60s --log-level warn
     volumes:
       - '/var/run/docker.sock:/var/run/docker.sock'
     restart: unless-stopped


### PR DESCRIPTION
30.08 обновление образа снесло run-baza-1 и не подняло новый. Цепочка: база не завершилась по SIGTERM за дефолтные 10s (dockerd: "Container failed to exit within 10s of kill - trying direct SIGKILL"), у watchtower истёк дедлайн на запрос к docker.sock ("Failed to stop container /run-baza-1 ... context deadline exceeded"), он счёл стоп неуспешным и не стал создавать замену. Docker при этом force-delete довёл до конца, так что restart: unless-stopped уже не помогал - восстанавливать было нечего.

Даём базе 60s на штатное закрытие и убираем --remove-volumes: в удалявшем запросе был v=1, именованные тома он не тронул, но держать этот флаг рядом с базой незачем.